### PR TITLE
Accept multiple addresses on an interface

### DIFF
--- a/templates/systemd-network.j2
+++ b/templates/systemd-network.j2
@@ -3,11 +3,7 @@
 [Match]
 Name={{ item.1.interface }}
 
-{% if item.1.address is defined %}
-[Address]
-{%   set addr_cidr = (item.1.address | string + '/' + item.1.netmask | string) | ipaddr('prefix') %}
-Address={{ item.1.address }}/{{ addr_cidr }}
-{% elif item.1.address is defined and (item.1.address | lower) == 'dhcp' %}
+{% if item.1.address is defined and (item.1.address | lower) == 'dhcp' %}
 [DHCP]
 UseDNS={{ (item.1.usedns | default(false) | bool) | ternary('yes', 'no') }}
 UseNTP=yes

--- a/templates/systemd-network.j2
+++ b/templates/systemd-network.j2
@@ -17,16 +17,30 @@ Gateway={{ route['gateway'] }}
 Metric={{ 20 + loop.index }}
 
 {% endfor %}
+
+{%- if item.1.address is not defined %}
+{#   Address is not defined #}
+{%   set _addresses = [] %}
+{% elif item.1.address is iterable and not string %}
+{#   Address is a list, multiple addresses defined #}
+{%   set _addresses = item.1.address %}
+{% else %}
+{#   Single address defined #}
+{%   set _addresses = [item.1] %}
+{% endif %}
+
 [Network]
-{% if item.1.address is defined %}
-{%   set addr_cidr = (item.1.address | string + '/' + item.1.netmask | string) | ipaddr('prefix') %}
-Address={{ item.1.address }}/{{ addr_cidr }}
-{% elif item.1.address is defined and (item.1.address | lower) == 'dhcp' %}
+{% for _addr in _addresses %}
+{%   if _addr.address == 'dhcp' %}
 DHCP=yes
-{% endif %}
-{% if item.1.address is defined and item.1.gateway is defined %}
+{%   else %}
+{%   set _addr_cidr = (item.1.address | string + '/' + item.1.netmask | default('') | string).rstrip('/') | ipaddr('host/prefix') %}
+Address={{ _addr_cidr }}
+{%   endif %}
+{%   if _addr.gateway is defined %}
 Gateway={{ item.1.gateway }}
-{% endif %}
+{%   endif %}
+{% endfor %}
 {% if item.1.bridge is defined %}
 Bridge={{ item.1.bridge }}
 {% elif item.1.bond is defined %}


### PR DESCRIPTION
These are all valid configurations:

```yaml
systemd_networks:
  - interface: dummy1
    address: 10.0.0.100
    netmask: 255.255.255.0
    gateway: 10.0.0.1
  - interface: dummy2
    address: 10.0.1.100/24
  - interface: dummy3
    address:
      - 10.0.2.100/24
      - address: 10.0.3.100
        netmask: 255.255.255.0
    gateway: 10.0.2.1
  - interface: eth12
    address: dhcp
```