### PR TITLE
Multiple addresses fix

### DIFF
--- a/templates/systemd-network.j2
+++ b/templates/systemd-network.j2
@@ -31,6 +31,9 @@ Metric={{ 20 + loop.index }}
 
 [Network]
 {% for _addr in _addresses %}
+{%   if _addr is string %}
+       set _addr = {}
+{%   endif %}
 {%   if _addr.address == 'dhcp' %}
 DHCP=yes
 {%   else %}

--- a/templates/systemd-network.j2
+++ b/templates/systemd-network.j2
@@ -37,7 +37,7 @@ Metric={{ 20 + loop.index }}
 {%   if _addr.address == 'dhcp' %}
 DHCP=yes
 {%   else %}
-{%   set _addr_cidr = (item.1.address | string + '/' + item.1.netmask | default('') | string).rstrip('/') | ipaddr('host/prefix') %}
+{%   set _addr_cidr = (_addr.address | string + '/' + _addr.netmask | default('') | string).rstrip('/') | ipaddr('host/prefix') %}
 Address={{ _addr_cidr }}
 {%   endif %}
 {%   if _addr.gateway is defined %}


### PR DESCRIPTION
Fixes the following configuration, list of host/prefix strings:
```yaml
systemd_networks:
  - interface: dummy3
    address:
      - 10.0.2.100/24
      - 10.0.3.100/24
```

Also fixes a problem where the wrong address is referenced when `address` is a list.